### PR TITLE
Make verus server bind to only one port

### DIFF
--- a/src/verus_server.cpp
+++ b/src/verus_server.cpp
@@ -318,15 +318,10 @@ int calcSi (double wBar) {
 
 void* sending_thread (void *arg)
 {
-    int s1;
     int i, ret;
     int sPkts;
     udp_packet_t *pdu;
     //struct timeval currentTime;
-
-    s1 = socket(AF_INET,SOCK_DGRAM,0);
-    if ( s1 == -1 )
-        displayError("socket error()");
 
     while (!terminate) {
         while (tempS > 0) {
@@ -338,7 +333,7 @@ void* sending_thread (void *arg)
                 pdu = udp_pdu_init(pktSeq, MTU, wBar, ssId);
                 //gettimeofday(&currentTime,NULL);
 
-                ret = sendto(s1, pdu, MTU, MSG_DONTWAIT, (struct sockaddr *)&adr_clnt, len_inet);
+                ret = sendto(s, pdu, MTU, MSG_DONTWAIT, (struct sockaddr *)&adr_clnt, len_inet);
 
                 if (ret < 0) {
                     // if UDP buffer of OS is full, we exit slow start and treat the current packet as lost


### PR DESCRIPTION
After Verus client sends handshake to the port that Verus server listens to, if the Verus client replies from a different port, the response will not be able to go through port restricted cone NAT successfully. It can be fixed by simply making Verus server bind to a single port, reusing the same socket. Notice that Verus client also binds to two ports, which is redundant too.
